### PR TITLE
Fixes issue #35

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -4,6 +4,10 @@ This page highlights some changes in the SDK.
 
 Not all changes will be listed, but you can always [compare by version tags](https://github.com/AquaticInformatics/aquarius-sdk-java/compare/v17.2.26...v17.2.28) to see the full source code difference.
 
+### 17.4.3
+
+- Fixed an Instant JSON deserialization bug.
+
 ### 17.4.1
 
 - Updated service models to support AQTS 2017.4

--- a/src/main/java/com/aquaticinformatics/aquarius/sdk/timeseries/serializers/InstantDeserializer.java
+++ b/src/main/java/com/aquaticinformatics/aquarius/sdk/timeseries/serializers/InstantDeserializer.java
@@ -7,16 +7,22 @@ import com.google.gson.JsonParseException;
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 import java.lang.reflect.Type;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.temporal.ChronoField;
 import java.util.Locale;
 
 public class InstantDeserializer implements JsonDeserializer<Instant> {
 
     public static final String ZoneFieldPattern = "ZZZZZ";
-    public static final String Pattern = "yyyy'-'MM'-'dd'T'HH':'mm':'ss'.'SSSSSSS" + ZoneFieldPattern;
+    public static final String DateAndTimePattern = "yyyy'-'MM'-'dd'T'HH':'mm':'ss";
+    public static final String FractionalSecondsPattern = "'.'SSSSSSS";
+    public static final String Pattern = DateAndTimePattern + FractionalSecondsPattern + ZoneFieldPattern;
 
-    public static final DateTimeFormatter FORMATTER = DateTimeFormatter
-            .ofPattern(Pattern)
-            .withLocale(Locale.US);
+    public static final DateTimeFormatter FORMATTER =
+            new DateTimeFormatterBuilder().appendPattern(DateAndTimePattern)
+                    .appendFraction(ChronoField.NANO_OF_SECOND, 0, 7, true)
+                    .appendPattern(ZoneFieldPattern)
+                    .toFormatter();
 
     public static final String JsonMaxValue = "MaxInstant";
     public static final String JsonMinValue = "MinInstant";

--- a/src/main/java/com/aquaticinformatics/aquarius/sdk/timeseries/serializers/InstantSerializer.java
+++ b/src/main/java/com/aquaticinformatics/aquarius/sdk/timeseries/serializers/InstantSerializer.java
@@ -6,10 +6,13 @@ import java.lang.reflect.Type;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.util.Locale;
 
 public class InstantSerializer implements JsonSerializer<Instant> {
 
-    public static final DateTimeFormatter FORMATTER = InstantDeserializer.FORMATTER
+    public static final DateTimeFormatter FORMATTER = DateTimeFormatter
+            .ofPattern(InstantDeserializer.Pattern)
+            .withLocale(Locale.US)
             .withZone( ZoneId.of("UTC"));
 
     @Override

--- a/src/test/java/com/aquaticinformatics/aquarius/sdk/timeseries/serializers/InstantDeserializerTest.java
+++ b/src/test/java/com/aquaticinformatics/aquarius/sdk/timeseries/serializers/InstantDeserializerTest.java
@@ -40,6 +40,8 @@ public class InstantDeserializerTest {
         return new Object[]{
                 new Object[]{"Xmas 2015 AEST", "2015-12-25T00:00:00.1234567+10:00", Instant.parse("2015-12-24T14:00:00.1234567Z")},
                 new Object[]{"Xmas 2016 UTC", "2016-12-25T00:00:00.1234567Z", Instant.parse("2016-12-25T00:00:00.1234567Z")},
+                new Object[]{"Xmas 2016 UTC - 3 fractional second digits", "2016-12-25T00:00:00.123Z", Instant.parse("2016-12-25T00:00:00.123Z")},
+                new Object[]{"Xmas 2016 UTC - No fractional seconds", "2016-12-25T00:00:00Z", Instant.parse("2016-12-25T00:00:00Z")},
                 new Object[]{"Xmas 2017 PST", "2017-12-25T00:00:00.1234567-07:00", Instant.parse("2017-12-25T07:00:00.1234567Z")},
                 new Object[]{"MaxConcreteValue", InstantDeserializer.JsonMaxConcreteValue, InstantDeserializer.MaxConcreteValue},
                 new Object[]{"MinConcreteValue", InstantDeserializer.JsonMinConcreteValue, InstantDeserializer.MinConcreteValue},


### PR DESCRIPTION
The InstantDeserializer now considers up to 7 optional fractional seconds digits.

@zmoore-usgs This should fix it.