### PR TITLE
Issue-43 Authenticate using the Publish endpoint instead of the Provisioning endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ add the following dependency to your project's `pom.xml`:
 <dependency>
   <groupId>com.aquaticinformatics</groupId>
   <artifactId>aquarius.sdk</artifactId>
-  <version>18.4.1</version>
+  <version>18.4.2</version>
 </dependency>
 ```
 
@@ -35,7 +35,7 @@ To use this project as a dependency with [sbt](http://www.scala-sbt.org)
 add the following dependency to your project's `build.sbt`:
 
 ```scala
-libraryDependencies += "com.aquaticinformatics" % "aquarius.sdk" % "18.4.1"
+libraryDependencies += "com.aquaticinformatics" % "aquarius.sdk" % "18.4.2"
 ```
 
 ### Gradle
@@ -44,7 +44,7 @@ To use this project as a dependency with [Gradle](https://gradle.org/),
 add the following dependency to your project's `build.gradle`:
 
 ```groovy
-compile "com.aquaticinformatics:aquarius.sdk:18.4.1"
+compile "com.aquaticinformatics:aquarius.sdk:18.4.2"
 ```
 
 ### Others
@@ -54,12 +54,12 @@ To use this project as a dependency of another build system, a
 can be created by running the following commands:
 
 ```sh
-git clone --branch v18.4.1 https://github.com/AquaticInformatics/aquarius-sdk-java.git
+git clone --branch v18.4.2 https://github.com/AquaticInformatics/aquarius-sdk-java.git
 cd aquarius-sdk-java
 mvn package
 ```
 
-The generated JAR file will be at `target/aquarius-sdk-18.4.1.jar`.
+The generated JAR file will be at `target/aquarius-sdk-18.4.2.jar`.
 
 ## Getting Help
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -4,6 +4,10 @@ This page highlights some changes in the SDK.
 
 Not all changes will be listed, but you can always [compare by version tags](https://github.com/AquaticInformatics/aquarius-sdk-java/compare/v17.2.26...v17.2.28) to see the full source code difference.
 
+### 18.4.2
+
+- Authenticate against the Publish endpoint instead of Provisioning, since that endpoint is more likely to be active and able to quickly respond. This internal change should be invisible to SDK consumers.
+
 ### 18.4.1
 
 - Updated service models for the AQUARIUS Samples 2018.4 release

--- a/src/main/java/com/aquaticinformatics/aquarius/sdk/timeseries/AquariusClient.java
+++ b/src/main/java/com/aquaticinformatics/aquarius/sdk/timeseries/AquariusClient.java
@@ -90,7 +90,7 @@ public class AquariusClient implements AutoCloseable {
     }
 
     private void connect(String username, String password) {
-        String sessionToken = Provisioning.authenticate(username, password);
+        String sessionToken = Publish.authenticate(username, password);
 
         Provisioning.setAuthenticationToken(sessionToken);
         Publish.setAuthenticationToken(sessionToken);
@@ -102,7 +102,7 @@ public class AquariusClient implements AutoCloseable {
     }
 
     private void deleteSession(){
-        Provisioning.logoff();
+        Publish.logoff();
     }
 
     @Override


### PR DESCRIPTION
The Publish endpoint is more likely to be awake and able to respond to the request quickly.