### PR TITLE
Issue-49 Fixed enum deserialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ add the following dependency to your project's `pom.xml`:
 <dependency>
   <groupId>com.aquaticinformatics</groupId>
   <artifactId>aquarius.sdk</artifactId>
-  <version>18.5.1</version>
+  <version>18.5.2</version>
 </dependency>
 ```
 
@@ -35,7 +35,7 @@ To use this project as a dependency with [sbt](http://www.scala-sbt.org)
 add the following dependency to your project's `build.sbt`:
 
 ```scala
-libraryDependencies += "com.aquaticinformatics" % "aquarius.sdk" % "18.5.1"
+libraryDependencies += "com.aquaticinformatics" % "aquarius.sdk" % "18.5.2"
 ```
 
 ### Gradle
@@ -44,7 +44,7 @@ To use this project as a dependency with [Gradle](https://gradle.org/),
 add the following dependency to your project's `build.gradle`:
 
 ```groovy
-compile "com.aquaticinformatics:aquarius.sdk:18.5.1"
+compile "com.aquaticinformatics:aquarius.sdk:18.5.2"
 ```
 
 ### Others
@@ -54,12 +54,12 @@ To use this project as a dependency of another build system, a
 can be created by running the following commands:
 
 ```sh
-git clone --branch v18.5.1 https://github.com/AquaticInformatics/aquarius-sdk-java.git
+git clone --branch v18.5.2 https://github.com/AquaticInformatics/aquarius-sdk-java.git
 cd aquarius-sdk-java
 mvn package
 ```
 
-The generated JAR file will be at `target/aquarius-sdk-18.5.1.jar`.
+The generated JAR file will be at `target/aquarius-sdk-18.5.2.jar`.
 
 ## Getting Help
 

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -4,6 +4,10 @@ This page highlights some changes in the SDK.
 
 Not all changes will be listed, but you can always [compare by version tags](https://github.com/AquaticInformatics/aquarius-sdk-java/compare/v17.2.26...v17.2.28) to see the full source code difference.
 
+### 18.5.2
+
+- Enumeration values are now deserialized using case-insensitive logic.
+
 ### 18.5.1
 
 - Updated service models for the AQUARIUS Samples 2018.05 release

--- a/src/main/java/com/aquaticinformatics/aquarius/sdk/helpers/CaseInsensitiveEnumTypeAdapterFactory.java
+++ b/src/main/java/com/aquaticinformatics/aquarius/sdk/helpers/CaseInsensitiveEnumTypeAdapterFactory.java
@@ -1,0 +1,51 @@
+package com.aquaticinformatics.aquarius.sdk.helpers;
+
+import com.google.gson.Gson;
+import com.google.gson.TypeAdapter;
+import com.google.gson.TypeAdapterFactory;
+import com.google.gson.reflect.TypeToken;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+public class CaseInsensitiveEnumTypeAdapterFactory implements TypeAdapterFactory {
+    public <T> TypeAdapter<T> create(Gson gson, TypeToken<T> type) {
+        Class<T> rawType = (Class<T>) type.getRawType();
+        if (!rawType.isEnum()) {
+            return null;
+        }
+
+        final Map<String, T> lowercaseToConstant = new HashMap<String, T>();
+        for (T constant : rawType.getEnumConstants()) {
+            lowercaseToConstant.put(toLowercase(constant), constant);
+        }
+
+        return new TypeAdapter<T>() {
+            public void write(JsonWriter out, T value) throws IOException {
+                if (value == null) {
+                    out.nullValue();
+                } else {
+                    out.value(value.toString());
+                }
+            }
+
+            public T read(JsonReader reader) throws IOException {
+                if (reader.peek() == JsonToken.NULL) {
+                    reader.nextNull();
+                    return null;
+                } else {
+                    return lowercaseToConstant.get(toLowercase(reader.nextString()));
+                }
+            }
+        };
+    }
+
+    private String toLowercase(Object o) {
+        return o.toString().toLowerCase(Locale.US);
+    }
+}

--- a/src/main/java/com/aquaticinformatics/aquarius/sdk/helpers/SdkServiceClient.java
+++ b/src/main/java/com/aquaticinformatics/aquarius/sdk/helpers/SdkServiceClient.java
@@ -101,6 +101,8 @@ public class SdkServiceClient extends net.servicestack.client.JsonServiceClient 
     public GsonBuilder getGsonBuilder() {
         GsonBuilder gsonBuilder = super.getGsonBuilder();
 
+        gsonBuilder.registerTypeAdapterFactory(new CaseInsensitiveEnumTypeAdapterFactory());
+
         _fieldNamer.configure(gsonBuilder);
 
         if (_serializeNulls) {

--- a/src/test/java/com/aquaticinformatics/aquarius/sdk/helpers/CaseInsensitiveTypeAdapterFactoryTest.java
+++ b/src/test/java/com/aquaticinformatics/aquarius/sdk/helpers/CaseInsensitiveTypeAdapterFactoryTest.java
@@ -1,0 +1,81 @@
+package com.aquaticinformatics.aquarius.sdk.helpers;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+
+enum SodaEnum
+{
+    Coke,
+    Pepsi,
+}
+
+@RunWith(JUnitParamsRunner.class)
+public class CaseInsensitiveTypeAdapterFactoryTest {
+
+    private Gson gson;
+
+    @Before
+    public void forEachTest() {
+        gson = new GsonBuilder()
+            .registerTypeAdapterFactory(new CaseInsensitiveEnumTypeAdapterFactory())
+            .create();
+    }
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    private Object[] validDeserializationTests() {
+        return new Object[]{
+                new Object[]{"Pascal case", "Coke", SodaEnum.Coke},
+                new Object[]{"Weird mixed case", "cOKe", SodaEnum.Coke},
+                new Object[]{"lowercase", "pepsi", SodaEnum.Pepsi},
+                new Object[]{"UPPERCASE", "PEPSI", SodaEnum.Pepsi},
+        };
+    }
+
+    @Test
+    @Parameters(method = "validDeserializationTests")
+    public void fromJson_withValidText_ConvertsAsExpected(String reason, String jsonText, SodaEnum expected) {
+        SodaEnum actual = gson.fromJson(jsonText, SodaEnum.class);
+
+        assertEquals(reason, expected, actual);
+    }
+
+    private Object[] invalidDeserializationTests() {
+        return new Object[]{
+                new Object[]{"Null should not deserialize", null},
+                new Object[]{"Unknown type", "SevenUp"},
+        };
+    }
+
+    @Test
+    @Parameters(method = "invalidDeserializationTests")
+    public void fromJson_withInvalidText_ReturnsNull(String reason, String jsonText){
+        SodaEnum actual = gson.fromJson(jsonText, SodaEnum.class);
+        assertEquals(reason, null, actual);
+    }
+
+    private Object[] validSerializationTests() {
+        return new Object[]{
+                new Object[]{SodaEnum.Coke, "\"Coke\""},
+                new Object[]{SodaEnum.Pepsi, "\"Pepsi\""},
+        };
+    }
+
+    @Test
+    @Parameters(method = "validSerializationTests")
+    public void toJson_ConvertsAsExpected(SodaEnum value, String expected) {
+        String actual = gson.toJson(value);
+
+        assertEquals("Serialized to json", expected, actual);
+    }
+}


### PR DESCRIPTION
Added a type adapter to deserialize any enumeration type using case-insensitive logic.

This works around a ServiceStack type generation bug that would serialize a value as "USGSValue" but generate a Java enumeration class expecting "UsgsValue".