### PR TITLE
Issue-56 Fixed a Maven dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,11 @@
         </configuration>
       </plugin>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-project-info-reports-plugin</artifactId>
+        <version>2.9</version>
+      </plugin>
+      <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
         <configuration>
           <descriptorRefs>


### PR DESCRIPTION
Not sure why it had been building all along, but this plugin definition has been missing from day 1.
But only today did the AppVeyor build stop working because of it.