### PR TITLE
Issue-74 Fixed a Javadoc comment which won't allow non-escaped characters

### DIFF
--- a/src/main/java/com/aquaticinformatics/aquarius/sdk/timeseries/servicemodels/Provisioning.java
+++ b/src/main/java/com/aquaticinformatics/aquarius/sdk/timeseries/servicemodels/Provisioning.java
@@ -4590,7 +4590,7 @@ public class Provisioning
     public static class ApprovalLevelBase
     {
         /**
-        * Approval Level. Values >=1000 are locking levels
+        * Approval Level. Values of 1000 or higher are locking levels
         */
         @ApiMember(DataType="long integer", Description="Approval Level. Values >=1000 are locking levels", IsRequired=true)
         public Long ApprovalLevel = null;


### PR DESCRIPTION
I hate Java some days.