### PR TITLE
Issue-74 Fixed a Javadoc comment which won't allow non-escaped characacters

### DIFF
--- a/src/main/java/com/aquaticinformatics/aquarius/sdk/timeseries/servicemodels/Provisioning.java
+++ b/src/main/java/com/aquaticinformatics/aquarius/sdk/timeseries/servicemodels/Provisioning.java
@@ -3162,7 +3162,7 @@ public class Provisioning
     public static class ApprovalLevel
     {
         /**
-        * Approval Level. Values >=1000 are locking levels
+        * Approval Level. Values 1000 or higher are locking levels
         */
         @ApiMember(DataType="long integer", Description="Approval Level. Values >=1000 are locking levels", IsRequired=true)
         public Long Level = null;


### PR DESCRIPTION
I really hate Java some days.