### PR TITLE
AT-1504 Restore maven versioning from appveyor build version

### DIFF
--- a/appveyor-mvn-release.yml
+++ b/appveyor-mvn-release.yml
@@ -87,7 +87,7 @@ build_script:
         Start-Sleep -Seconds 1800
       }
   - ps: (Get-Content "$env:VERSION_INFO_PATH").replace("$env:VERSION_INFO_TARGET", "$env:APPVEYOR_BUILD_VERSION") | Set-Content "$env:VERSION_INFO_PATH"
-  - mvn -B site site:stage deploy -P release
+  - mvn -B site site:stage deploy -P release -Drevision=%APPVEYOR_BUILD_VERSION%
 
 # Maven runs the tests as part of the build, so we don't need to run them again
 test: off

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   
   <groupId>com.aquaticinformatics</groupId>
   <artifactId>aquarius.sdk</artifactId>
-  <version>25.3.0</version>
+  <version>${revision}</version>
   <packaging>jar</packaging>
 
   <name>aquarius-sdk-java</name>
@@ -46,6 +46,7 @@
   <properties>
     <java.version>1.8</java.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <revision>1.0.0-SNAPSHOT</revision>
   </properties>
 
   <distributionManagement>


### PR DESCRIPTION
@AquaticInformatics/artemis @AquaticInformatics/nautilus 

I've restored the logic applying the AppVeyor build version to Maven build, with a fallback to `1.0.0-SNAPSHOT` as a default (the fallback is needed to allow functions that don't need a version, such as 'clean').

For now I've updated AppVeyor to build to a `25.3.{build}-SNAPSHOT` version, and we can remove the `-SNAPSHOT` when we have a release ready.

AFAIK this should work, this is the documented approach, but there must have been some issue, so I'll open as a draft for now and discuss with @AlvinLee-AI tomorrow.