### PR TITLE
Feature/at 1504 fix deployments

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,13 @@
         <version>3.9.0</version>
       </plugin>
 
+      <!-- Set version to avoid out-of-date default (3.3) -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-site-plugin</artifactId>
+        <version>3.21.0</version>
+      </plugin>
+
       <!-- Bundles source, dependencies, modules, and site documentation into single assembly-->
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -130,6 +130,31 @@
           <publishingServerId>central</publishingServerId>
         </configuration>
         </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>flatten-maven-plugin</artifactId>
+        <version>1.1.0</version>
+        <configuration>
+          <updatePomFile>true</updatePomFile>
+          <flattenMode>resolveCiFriendliesOnly</flattenMode>
+        </configuration>
+        <executions>
+          <execution>
+            <id>flatten</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>flatten</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>flatten.clean</id>
+            <phase>clean</phase>
+            <goals>
+              <goal>clean</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
@AquaticInformatics/artemis @AquaticInformatics/nautilus 

Adds the  `flatten-maven-plugin` to strip non-consumable artifacts, and also references the `maven-site-plugin` - the `maven-project-info-reports-plugin` needs it and falls back to an older version (3.3) if not defined, which is causing some build issues.

This has been tested in AppVeyor and works to deploy to maven central. Once this is merged, develop should be merged to master so we can see those changes reflected in the manual AppVeyor build.